### PR TITLE
Getting contents of a collection

### DIFF
--- a/lib/google_drive/session.rb
+++ b/lib/google_drive/session.rb
@@ -224,6 +224,11 @@ module GoogleDrive
           return Collection.new(self, url)
         end
 
+        # Returns the root collection
+        def root_collection
+          Collection.new self
+        end
+
         # Creates new spreadsheet and returns the new GoogleDrive::Spreadsheet.
         #
         # e.g.
@@ -352,13 +357,19 @@ module GoogleDrive
         end
         
         def entry_element_to_file(entry) #:nodoc:
+          type, resourceId = entry.css("gd|resourceId").text.split ':'
           title = entry.css("title").text
-          worksheets_feed_link = entry.css(
-            "link[rel='http://schemas.google.com/spreadsheets/2006#worksheetsfeed']")[0]
-          if worksheets_feed_link
-            return Spreadsheet.new(self, worksheets_feed_link["href"], title)
+
+          case type
+          when 'folder'
+            url = "https://docs.google.com/feeds/default/private/full/folder%3A#{resourceId}"
+            Collection.new self, url
+          when 'spreadsheet'
+            worksheets_feed_link = entry.css(
+              "link[rel='http://schemas.google.com/spreadsheets/2006#worksheetsfeed']")[0]
+            Spreadsheet.new(self, worksheets_feed_link["href"], title)
           else
-            return GoogleDrive::File.new(self, entry)
+            GoogleDrive::File.new(self, entry)
           end
         end
 


### PR DESCRIPTION
Things I added
- Get a root collection (session.root_collection)
- Extended Collection#files to filter its contents by params and type (spreadsheet, document, folder)

Before the Collection#files returned all the contents as File and Collection. One thing I noticed is that it returned folders as File objects. I have changed that, not it returns folders as Collection objects. Do you think `files` method should return only files and not collections?
