### PR TITLE
Fix: collection is not removed from Google Drive

### DIFF
--- a/lib/google_drive/collection.rb
+++ b/lib/google_drive/collection.rb
@@ -15,7 +15,7 @@ module GoogleDrive
         include(Util)
         
         #:nodoc:
-        ROOT_URL = "https://docs.google.com/feeds/default/private/full/folder%3Aroot"
+        ROOT_URL = "#{API_URL}folder%3Aroot"
 
         alias collection_feed_url document_feed_url
         

--- a/lib/google_drive/file.rb
+++ b/lib/google_drive/file.rb
@@ -28,7 +28,7 @@ module GoogleDrive
             @document_feed_url = entry_or_url
           else
             @document_feed_entry = entry_or_url
-            @document_feed_url = entry_or_url.css("link[rel='self']")[0]["href"]
+            @document_feed_url = "#{API_URL}#{resource_type}%3A#{resource_id}"
           end
           @acl = nil
         end
@@ -49,6 +49,11 @@ module GoogleDrive
 
         def resource_id
           return self.document_feed_entry.css("gd|resourceId").text.split(/:/)[1]
+        end
+
+        # Get the type of resourse: document, spreadsheet, folder etc.
+        def resource_type
+          return self.document_feed_entry.css("gd|resourceId").text.split(/:/)[0]
         end
 
         # Title of the file.
@@ -74,7 +79,7 @@ module GoogleDrive
               return orig_acl_feed_url
             when %r{^https?://docs.google.com/feeds/acl/private/full/([^\?]*)(\?.*)?$}
               # URL of old API version. Converts to v3 URL.
-              return "https://docs.google.com/feeds/default/private/full/#{$1}/acl"
+              return "#{API_URL}#{$1}/acl"
             else
               raise(GoogleDrive::Error,
                 "ACL feed URL is in unknown format: #{orig_acl_feed_url}")

--- a/lib/google_drive/session.rb
+++ b/lib/google_drive/session.rb
@@ -119,7 +119,7 @@ module GoogleDrive
         #   session.files("title" => "hoge", "title-exact" => "true")
         def files(params = {})
           url = concat_url(
-              "https://docs.google.com/feeds/default/private/full?v=3", "?" + encode_query(params))
+              "#{API_URL}?v=3", "?" + encode_query(params))
           doc = request(:get, url, :auth => :writely)
           return doc.css("feed > entry").map(){ |e| entry_element_to_file(e) }
         end
@@ -239,7 +239,7 @@ module GoogleDrive
           if ["docs.google.com", "drive.google.com"].include?(uri.host) &&
               uri.fragment =~ /^folders\/(.+)$/
             # Looks like a URL of human-readable collection page. Converts to collection feed URL.
-            url = "https://docs.google.com/feeds/default/private/full/folder%3A#{$1}"
+            url = "#{API_URL}folder%3A#{$1}"
           end
           return Collection.new(self, url)
         end
@@ -309,7 +309,7 @@ module GoogleDrive
         # Uploads a file. Reads content from +io+.
         # Returns a GoogleSpreadsheet::File object.
         def upload_from_io(io, title = "Untitled", params = {})
-          doc = request(:get, "https://docs.google.com/feeds/default/private/full?v=3",
+          doc = request(:get, "#{API_URL}?v=3",
               :auth => :writely)
           initial_url = doc.css(
               "link[rel='http://schemas.google.com/g/2005#resumable-create-media']")[0]["href"]

--- a/lib/google_drive/spreadsheet.rb
+++ b/lib/google_drive/spreadsheet.rb
@@ -103,7 +103,6 @@ module GoogleDrive
         # Creates copy of this spreadsheet with the given title.
         def duplicate(new_title = nil)
           new_title ||= (self.title ? "Copy of " + self.title : "Untitled")
-          post_url = "https://docs.google.com/feeds/default/private/full/"
           header = {"GData-Version" => "3.0", "Content-Type" => "application/atom+xml"}
           xml = <<-"EOS"
             <entry xmlns='http://www.w3.org/2005/Atom'>
@@ -112,7 +111,7 @@ module GoogleDrive
             </entry>
           EOS
           doc = @session.request(
-              :post, post_url, :data => xml, :header => header, :auth => :writely)
+              :post, API_URL, :data => xml, :header => header, :auth => :writely)
           ss_url = doc.css(
               "link[rel='http://schemas.google.com/spreadsheets/2006#worksheetsfeed']")[0]["href"]
           return Spreadsheet.new(@session, ss_url, new_title)

--- a/lib/google_drive/util.rb
+++ b/lib/google_drive/util.rb
@@ -7,6 +7,9 @@ require "cgi"
 module GoogleDrive
     
     module Util #:nodoc:
+
+        # The beginning of API URL that is used in all requests (version 3)
+        API_URL = 'https://docs.google.com/feeds/default/private/full/'
         
         EXT_TO_CONTENT_TYPE = {
             ".csv" =>"text/csv",

--- a/test/test_google_drive.rb
+++ b/test/test_google_drive.rb
@@ -15,7 +15,6 @@ class TC_GoogleDrive < Test::Unit::TestCase
     @@session = nil
     
     def test_spreadsheet_online()
-      
       session = get_session()
       
       ss_title = "#{PREFIX}spreadsheet"
@@ -214,13 +213,18 @@ class TC_GoogleDrive < Test::Unit::TestCase
 
       # Deletes file.
       delete_test_file(file, true)
+      # Ensure the files is removed from collection.
       files = collection.files("title" => test_file_name, "title-exact" => true)
       assert_equal(0, files.size)
+      # Ensure the file is removed from Google Drive.
+      refute(session.files().any?{|a| a.title == test_collection_name})
 
       # Deletes collection.
       delete_test_file(collection, true)
+      # Ensure the collection is removed from root.
       assert_nil(root.subcollection_by_title(test_collection_name))
-      
+      # Ensure the collection is removed from Google Drive.
+      refute(session.files(showfolders: true).any?{|a| a.title == test_collection_name})
     end
     
     def test_collection_offline()


### PR DESCRIPTION
Thank you for pulling  my collection method additions. I have found a bug here. When calling `delete` on a collection it removed the collection from its parent but did not actually delete this collection from Google Drive storage.

For example, suppose there was a collections named `sub` inside root. Calling `sub.delete()` would remove it from root, but it would still be present in Google Drive. It sounds weird to me. But I think it is because of how collections work in Google Drive. This is how I understand it: collections are more like labels or tags which are assigned to a resource. And it is possible for a resource to exist while having no parent collections.

Ok, so the collection was not deleted from storage because `document_feed_url` of the collection was incorrect. For example, it was 

```
https://docs.google.com/feeds/default/private/full/folder%3Aroot/contents/folder%3A0B5J-5NxXCH7OOHExMTBhTXNoN1E
```

while it should always be in form of

```
https://docs.google.com/feeds/default/private/full/folder:id
```

I have also added a test to ensure collections and files are completely deleted from storage. 
