### PR TITLE
Correct the headers hash key for OAuth2

### DIFF
--- a/lib/google_drive/oauth2_fetcher.rb
+++ b/lib/google_drive/oauth2_fetcher.rb
@@ -35,9 +35,9 @@ module GoogleDrive
         
         def request_raw(method, url, data, extra_header, auth)
           if method == :delete || method == :get
-            raw_res = @oauth2_token.request(method, url, {:header => extra_header})
+            raw_res = @oauth2_token.request(method, url, {:headers => extra_header})
           else
-            raw_res = @oauth2_token.request(method, url, {:header => extra_header, :body => data})
+            raw_res = @oauth2_token.request(method, url, {:headers => extra_header, :body => data})
           end
           return Response.new(raw_res)
         end


### PR DESCRIPTION
The OAuth2::Client#request method in the OAuth2 library looks for header
values using the hash key :headers, not :header.

In version 0.7.1 of the OAuth2 library, this can be seen in OAuth2::Client#request:88.

Thanks!
