### PR TITLE
To enable enter multiline in the cell, Escape LF char as &#A;.

### DIFF
--- a/lib/google_drive/worksheet.rb
+++ b/lib/google_drive/worksheet.rb
@@ -300,7 +300,7 @@ module GoogleDrive
                     <id>#{h(id)}</id>
                     <link rel="edit" type="application/atom+xml"
                       href="#{h(edit_url)}"/>
-                    <gs:cell row="#{h(row)}" col="#{h(col)}" inputValue="#{h(value)}"/>
+                    <gs:cell row="#{h(row)}" col="#{h(col)}" inputValue="#{h(value).gsub("\n", '&#xA;')}"/>
                   </entry>
                 EOS
               end


### PR DESCRIPTION
To enable enter multiline in the cell, Escape LF char as &#A;.
