### PR TITLE
export document 

### DIFF
--- a/lib/google_drive/file.rb
+++ b/lib/google_drive/file.rb
@@ -149,6 +149,14 @@ module GoogleDrive
                   [self.available_content_types])
             end
           end
+
+	  if params[:export_format]
+            if AVAILABLE_EXPORT_FORMATS.include? params[:export_format]
+              url ="https://docs.google.com/feeds/download/documents/Export?id=" + resource_id.split(":")[1] + "&exportFormat=" + params[:export_format] + "&format=" + params[:export_format]
+            else
+              raise "You can export document only in theese formats: " + AVAILABLE_EXPORT_FORMATS.join(",")
+            end
+          end
           # TODO Use streaming if possible.
           body = @session.request(:get, url, :response_type => :raw, :auth => :writely)
           io.write(body)

--- a/lib/google_drive/util.rb
+++ b/lib/google_drive/util.rb
@@ -33,6 +33,8 @@ module GoogleDrive
             ".zip" =>"application/zip",
             ".swf" =>"application/x-shockwave-flash",
         }
+
+	AVAILABLE_EXPORT_FORMATS = ["docx","doc","pdf","html","txt","rtf","odt","zip","png","jpeg"]
         
       module_function
         


### PR DESCRIPTION
for exporting pass param export_format in download function
example:
download_to_string(export_format: "pdf")

hacky check for documents, won't work for spreadsheets and presentations (need differentiation for google drive file type from resource_id.split(":")[0] )
