### PR TITLE
Change variable name to remove warning under Ruby 1.9.2

### DIFF
--- a/lib/google_drive/worksheet.rb
+++ b/lib/google_drive/worksheet.rb
@@ -310,15 +310,15 @@ module GoogleDrive
 
               batch_url = concat_url(@cells_feed_url, "/batch")
               result = @session.request(:post, batch_url, :data => xml)
-              result.css("atom|entry").each() do |entry|
-                interrupted = entry.css("batch|interrupted")[0]
+              result.css("atom|entry").each() do |xml_entry|
+                interrupted = xml_entry.css("batch|interrupted")[0]
                 if interrupted
                   raise(GoogleDrive::Error, "Update has failed: %s" %
                     interrupted["reason"])
                 end
-                if !(entry.css("batch|status").first["code"] =~ /^2/)
+                if !(xml_entry.css("batch|status").first["code"] =~ /^2/)
                   raise(GoogleDrive::Error, "Updating cell %s has failed: %s" %
-                    [entry.css("atom|id").text, entry.css("batch|status")[0]["reason"]])
+                    [xml_entry.css("atom|id").text, xml_entry.css("batch|status")[0]["reason"]])
                 end
               end
 


### PR DESCRIPTION
Ruby 1.9.2 was complaining about a variable being hidden. By renaming the variable from entry to xml_entry, the warning goes away.
