### PR TITLE
account.yml.example should use auth_method instead of auth_type

### DIFF
--- a/test/account.yaml.example
+++ b/test/account.yaml.example
@@ -4,18 +4,18 @@
 # If you want to automate it, copy this file to account.yaml and set some proper values.
 
 # Stores session to $HOME/.ruby_google_spreadsheet.token and reuse it.
-auth_type: "saved_session"
+auth_method: "saved_session"
 
 # Or, you can use either of the sections below instead.
 
 # Writes your Google account information here directly.
 #
-# auth_type: "client_login"
+# auth_method: "client_login"
 # mail: "example@gmail.com"
 # password: "YOUR PASSWORD"
 
 # Use OAuth2.
 #
-# auth_type: "oauth2"
+# auth_method: "oauth2"
 # oauth2_client_id: "YOUR_CLIENT_ID"
 # oauth2_client_secret: "YOUR_CLIENT_SECRET"


### PR DESCRIPTION
Matches the parameters used at https://github.com/gimite/google-drive-ruby/blob/master/test/test_google_drive.rb#L289
