### PR TITLE
fix #38: make batch size configurable

### DIFF
--- a/lib/google_drive/worksheet.rb
+++ b/lib/google_drive/worksheet.rb
@@ -18,7 +18,7 @@ module GoogleDrive
         include(Util)
 
         def initialize(session, spreadsheet, cells_feed_url, title = nil) #:nodoc:
-          
+
           @session = session
           @spreadsheet = spreadsheet
           @cells_feed_url = cells_feed_url
@@ -29,11 +29,17 @@ module GoogleDrive
           @numeric_values = nil
           @modified = Set.new()
           @list = nil
-          
+
+          @save_batch_size = 250
+
         end
 
         # URL of cell-based feed of the worksheet.
         attr_reader(:cells_feed_url)
+
+        # Batch size for saving changes
+        # Lower this value when experiencing issues with timeout errors as per issue #38.
+        attr_writer(:save_batch_size)
 
         # URL of worksheet feed URL of the worksheet.
         def worksheet_feed_url
@@ -73,7 +79,7 @@ module GoogleDrive
         end
 
         # Updates content of the cell.
-        # Arguments in the bracket must be either (row number, column number) or cell name. 
+        # Arguments in the bracket must be either (row number, column number) or cell name.
         # Note that update is not sent to the server until you call save().
         # Top-left cell is [1, 1].
         #
@@ -136,7 +142,7 @@ module GoogleDrive
           reload() if !@cells
           return @numeric_values[[row, col]]
         end
-        
+
         # Row number of the bottom-most non-empty row.
         def num_rows
           reload() if !@cells
@@ -211,7 +217,7 @@ module GoogleDrive
         # Reloads content of the worksheets from the server.
         # Note that changes you made by []= etc. is discarded if you haven't called save().
         def reload()
-          
+
           doc = @session.request(:get, @cells_feed_url)
           @max_rows = doc.css("gs|rowCount").text.to_i()
           @max_cols = doc.css("gs|colCount").text.to_i()
@@ -232,12 +238,12 @@ module GoogleDrive
           @modified.clear()
           @meta_modified = false
           return true
-          
+
         end
 
         # Saves your changes made by []=, etc. to the server.
         def save()
-          
+
           sent = false
 
           if @meta_modified
@@ -280,7 +286,7 @@ module GoogleDrive
 
             # Updates cell values using batch operation.
             # If the data is large, we split it into multiple operations, otherwise batch may fail.
-            @modified.each_slice(250) do |chunk|
+            @modified.each_slice(@save_batch_size) do |chunk|
 
               xml = <<-EOS
                 <feed xmlns="http://www.w3.org/2005/Atom"
@@ -328,9 +334,9 @@ module GoogleDrive
             sent = true
 
           end
-          
+
           return sent
-          
+
         end
 
         # Calls save() and reload().
@@ -358,7 +364,7 @@ module GoogleDrive
         # See this document for details:
         # http://code.google.com/intl/en/apis/spreadsheets/docs/3.0/developers_guide_protocol.html#TableFeeds
         def add_table(table_title, summary, columns, options)
-          
+
           warn(
               "DEPRECATED: Google Spreadsheet Table and Record feeds are deprecated and they " +
               "will not be available after March 2012.")
@@ -385,7 +391,7 @@ module GoogleDrive
 
           result = @session.request(:post, self.spreadsheet.tables_feed_url, :data => xml)
           return Table.new(@session, result)
-          
+
         end
 
         # DEPRECATED: Table and Record feeds are deprecated and they will not be available after
@@ -408,7 +414,7 @@ module GoogleDrive
           return entry.css(
             "link[rel='http://schemas.google.com/spreadsheets/2006#listfeed']")[0]["href"]
         end
-        
+
         # Provides access to cells using column names, assuming the first row contains column
         # names. Returned object is GoogleDrive::List which you can use mostly as
         # Array of Hash.
@@ -424,7 +430,7 @@ module GoogleDrive
         def list
           return @list ||= List.new(self)
         end
-        
+
         # Returns a [row, col] pair for a cell name string.
         # e.g.
         #   worksheet.cell_name_to_row_col("C2")  #=> [2, 3]
@@ -451,7 +457,7 @@ module GoogleDrive
           fields[:title] = @title if @title
           return "\#<%p %s>" % [self.class, fields.map(){ |k, v| "%s=%p" % [k, v] }.join(", ")]
         end
-        
+
       private
 
         def parse_cell_args(args)
@@ -469,7 +475,7 @@ module GoogleDrive
                 "Arguments must be either one String or two Integer's, but are %p" % [args])
           end
         end
-        
+
     end
-    
+
 end


### PR DESCRIPTION
When experiencing issues with timeout errors in Worksheet#save it's
necessary to limit the batch size to something much lower like 25
(default is 250). This patch simply makes the batch size configurable.
