### PR TITLE
Make number of header lines configurable

### DIFF
--- a/lib/google_drive/list.rb
+++ b/lib/google_drive/list.rb
@@ -18,18 +18,19 @@ module GoogleDrive
         
         include(Enumerable)
         
-        def initialize(worksheet) #:nodoc:
+        def initialize(worksheet, header_rows = 1) #:nodoc:
           @worksheet = worksheet
+          @header_rows = header_rows
         end
         
         # Number of non-empty rows in the worksheet excluding the first row.
         def size
-          return @worksheet.num_rows - 1
+          return @worksheet.num_rows - @header_rows
         end
         
         # Returns Hash-like object (GoogleDrive::ListRow) for the row with the
         # index. Keys of the object are colum names (the first row).
-        # The second row has index 0.
+        # The first data row has index 0.
         #
         # Note that updates to the returned object are not sent to the server until
         # you call GoogleDrive::Worksheet#save().
@@ -94,15 +95,15 @@ module GoogleDrive
         end
         
         def get(index, key) #:nodoc:
-          return @worksheet[index + 2, key_to_col(key)]
+          return @worksheet[index + @header_rows + 1, key_to_col(key)]
         end
         
         def numeric_value(index, key) #:nodoc:
-          return @worksheet.numeric_value(index + 2, key_to_col(key))
+          return @worksheet.numeric_value(index + @header_rows + 1, key_to_col(key))
         end
         
         def set(index, key, value) #:nodoc:
-          @worksheet[index + 2, key_to_col(key)] = value
+          @worksheet[index + @header_rows + 1, key_to_col(key)] = value
         end
         
       private

--- a/lib/google_drive/worksheet.rb
+++ b/lib/google_drive/worksheet.rb
@@ -28,7 +28,6 @@ module GoogleDrive
           @input_values = nil
           @numeric_values = nil
           @modified = Set.new()
-          @list = nil
           
         end
 
@@ -421,8 +420,8 @@ module GoogleDrive
         #   worksheet.list.push({"x" => "5", "y" => "6"})
         #
         # Note that update is not sent to the server until you call save().
-        def list
-          return @list ||= List.new(self)
+        def list(header_rows = 1)
+          return List.new(self, header_rows)
         end
         
         # Returns a [row, col] pair for a cell name string.


### PR DESCRIPTION
I want to reference columns by an id in a header row, which is exactly what Worksheet#list() does ... except I have two header rows, the first being the ID row and the second a human-readable description of the column.

I extended list() with an optional parameter for the number of header rows.  The first row is still the one used as the ID, but it ignores the number of rows specified by the argument.

Since the result of list() is no longer invariant, I changed the code not to cache the returned object.  List just references back to Workspace, so it's instantiation should be very cheap (especially compared to network latencies).
