### PR TITLE
Memoize Worksheet#num_cols and num_rows

### DIFF
--- a/lib/google_drive/worksheet.rb
+++ b/lib/google_drive/worksheet.rb
@@ -91,6 +91,13 @@ module GoogleDrive
           @modified.add([row, col])
           self.max_rows = row if row > @max_rows
           self.max_cols = col if col > @max_cols
+          if value.empty?
+            @num_rows = nil
+            @num_cols = nil
+          else
+            @num_rows = row if row > num_rows
+            @num_cols = col if col > num_cols
+          end
         end
 
         # Updates cells in a rectangle area by a two-dimensional Array.
@@ -140,13 +147,13 @@ module GoogleDrive
         # Row number of the bottom-most non-empty row.
         def num_rows
           reload() if !@cells
-          return @input_values.select(){ |(r, c), v| !v.empty? }.map(){ |(r, c), v| r }.max || 0
+          @num_rows ||= @input_values.select(){ |(r, c), v| !v.empty? }.map(){ |(r, c), v| r }.max || 0
         end
 
         # Column number of the right-most non-empty column.
         def num_cols
           reload() if !@cells
-          return @input_values.select(){ |(r, c), v| !v.empty? }.map(){ |(r, c), v| c }.max || 0
+          @num_cols ||= @input_values.select(){ |(r, c), v| !v.empty? }.map(){ |(r, c), v| c }.max || 0
         end
 
         # Number of rows including empty rows.
@@ -216,6 +223,9 @@ module GoogleDrive
           @max_rows = doc.css("gs|rowCount").text.to_i()
           @max_cols = doc.css("gs|colCount").text.to_i()
           @title = doc.css("feed > title")[0].text
+
+          @num_cols = nil
+          @num_rows = nil
 
           @cells = {}
           @input_values = {}


### PR DESCRIPTION
Optimize iterating over all ListRows in a Worksheet by memoizing the
`Worksheet#num_cols` and `Worksheet#num_rows` methods. For a worksheet
with about 1200 rows with 36 columns each this reduced the run-time of
the following code snippet from more than 1900 seconds to less than 3
seconds:

```
bookings = worksheet.list
pending = bookings.select{|row| row['Order ID'].present? and row['Status'] == 'pending'}
```

I used ruby-prof to trace where this time was spent. The results pretty
clearly showed that most of the time was spent inside the
`Worksheet#num_cols` method so that's where I started optimizing. Just
memoizing the result of that method shows such a drastic improvement in
runtime that I didn't bother doing any further optimizations.

ruby-prof call stack reports:

Before:

![ruby-prof-stack-before](https://f.cloud.github.com/assets/1900876/253302/cbc1b0f4-8bcb-11e2-80cb-2ad1d540cbd1.png)

After:

![ruby-prof-stack-after](https://f.cloud.github.com/assets/1900876/253301/cb987018-8bcb-11e2-9e40-038559bb0b79.png)
