### PR TITLE
Fix to 400 Returns on spreadsheet.document_feed_entry

### DIFF
--- a/lib/google_drive/spreadsheet.rb
+++ b/lib/google_drive/spreadsheet.rb
@@ -77,7 +77,7 @@ module GoogleDrive
 
         # URL of feed used in document list feed API.
         def document_feed_url
-          return "https://docs.google.com/feeds/documents/private/full/spreadsheet%3A#{self.key}"
+          return "https://spreadsheets.google.com/feeds/worksheets/#{self.key}/private/full"
         end
 
         # <entry> element of spreadsheet feed as Nokogiri::XML::Element.
@@ -85,8 +85,9 @@ module GoogleDrive
         # Set <tt>params[:reload]</tt> to true to force reloading the feed.
         def spreadsheet_feed_entry(params = {})
           if !@spreadsheet_feed_entry || params[:reload]
+            params = {"GData-Version" => "3.0"}
             @spreadsheet_feed_entry =
-                @session.request(:get, self.spreadsheet_feed_url).css("entry")[0]
+                @session.request(:get, self.spreadsheet_feed_url, params).css("entry")[0]
           end
           return @spreadsheet_feed_entry
         end


### PR DESCRIPTION
As of Feb 14, a 400 is returned on spreadsheet.document_feed_entry with an otherwise active and working client (i.e. spreadsheet row/col returns are successful). I had been using the gem since July with no issues prior. 

Further reports from other users: http://stackoverflow.com/questions/21778342/response-code-400-for-get-https-docs-google-com-feeds-documents-private-full & https://github.com/gimite/google-drive-ruby/issues/76

This is fixed by both appending GData Version and updating document_feed_url. 
