### PR TITLE
Fix typo in error message

### DIFF
--- a/lib/google_drive/worksheet.rb
+++ b/lib/google_drive/worksheet.rb
@@ -487,7 +487,7 @@ module GoogleDrive
             end
           else
             raise(ArgumentError,
-                "Arguments must be either one String or two Integer's, but are %p" % [args])
+                "Arguments must be either one String or two Integers, but are %p" % [args])
           end
         end
         


### PR DESCRIPTION
Almost too small a typo to care about, but then why have your gem _almost_ perfect?
