### PR TITLE
Fixing a bug where inputValue may be missing with the new Google Sheets.

### DIFF
--- a/lib/google_drive/worksheet.rb
+++ b/lib/google_drive/worksheet.rb
@@ -246,7 +246,7 @@ module GoogleDrive
             row = cell["row"].to_i()
             col = cell["col"].to_i()
             @cells[[row, col]] = cell.inner_text
-            @input_values[[row, col]] = cell["inputValue"]
+            @input_values[[row, col]] = cell["inputValue"] || cell.inner_text
             numeric_value = cell["numericValue"]
             @numeric_values[[row, col]] = numeric_value ? numeric_value.to_f() : nil
           end


### PR DESCRIPTION
Hi,

google-drive-ruby breaks with the new Google Sheets, because they have changed the XML: now the cells have an inputValue only when there really is a formula. Here is some sample XML from the cells feed of a new Google Sheet. As you can see, only the last one has an inputValue:

```
  <gs:cell row="3" col="4">fuga</gs:cell>

  <gs:cell row="4" col="1" numericValue="3.0">3</gs:cell>

  <gs:cell row="5" col="1" inputValue="=2+2" numericValue="4.0">4</gs:cell>
```

Because of the missing inputValue, the worksheets break in many places. For example:

```
2.0.0-p353 :022 > puts worksheet.rows
NoMethodError: undefined method `empty?' for nil:NilClass
    from /Users/yemartin/.rvm/gems/ruby-2.0.0-p353/gems/google_drive-0.3.7/lib/google_drive/worksheet.rb:161:in `block in num_cols'
    from /Users/yemartin/.rvm/gems/ruby-2.0.0-p353/gems/google_drive-0.3.7/lib/google_drive/worksheet.rb:161:in `select'
    from /Users/yemartin/.rvm/gems/ruby-2.0.0-p353/gems/google_drive-0.3.7/lib/google_drive/worksheet.rb:161:in `num_cols'
    from /Users/yemartin/.rvm/gems/ruby-2.0.0-p353/gems/google_drive-0.3.7/lib/google_drive/worksheet.rb:222:in `rows'
    from (irb):22
    from /Users/yemartin/.rvm/rubies/ruby-2.0.0-p353/bin/irb:12:in `<main>'
```

This pull request fixes this issues.

---

Note about testing this: I wanted to create an automated test but could not: apparently `session.create_spreadsheet` still creates old version Google Spreadsheets, that always have inputValue. So to reproduce the bug, you must manually create a new Google Sheet in Google Docs, after opting in to "Try the new Google Sheets".

Anyway, while I did not create a test for this issue, I did verify that all other tests pass:

```
$  ruby test/test_google_drive.rb
Run options:

# Running tests:

[1/4] TC_GoogleDrive#test_acl_online
This test will create files/spreadsheets/collections with your account,
read/write them and finally delete them (if everything succeeds).
Mail:
Password:
Finished tests in 102.589741s, 0.0390 tests/s, 1.0820 assertions/s.
4 tests, 111 assertions, 0 failures, 0 errors, 0 skips

ruby -v: ruby 2.0.0p353 (2013-11-22 revision 43784) [x86_64-darwin12.5.0]
```
