### PR TITLE
use updated url for export

### DIFF
--- a/lib/google_drive/spreadsheet.rb
+++ b/lib/google_drive/spreadsheet.rb
@@ -125,9 +125,8 @@ module GoogleDrive
         # In format such as "csv", only the worksheet specified with +worksheet_index+ is
         # exported.
         def export_as_string(format, worksheet_index = nil)
-          gid_param = worksheet_index ? "&gid=#{worksheet_index}" : ""
           format_string = "exportFormat=csv"
-          url = "https://docs.google.com/a/jombay.com/spreadsheets/d/#{key}/export?#{format_string}#{gid_param}"
+          url = "https://docs.google.com/a/jombay.com/spreadsheets/d/#{key}/export?#{format_string}"
           return @session.request(:get, url, :response_type => :raw)
         end
         


### PR DESCRIPTION
Since google drive has updated the url format of the documents, export_as_file method was not working as expected. It was resulting into an HTML file with 302 redirect message.
The updated url format is  https://docs.google.com/a/jombay.com/spreadsheets/d/#{key}/export?#{format_string}
