### PR TITLE
Added human_url method onto the Worksheet

### DIFF
--- a/google_drive.gemspec
+++ b/google_drive.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
 
   s.name = "google_drive"
-  s.version = "0.3.12"
+  s.version = "0.3.11"
   s.authors = ["Hiroshi Ichikawa"]
   s.email = ["gimite+github@gmail.com"]
   s.summary = "A library to read/write files/spreadsheets in Google Drive/Docs."


### PR DESCRIPTION
Added a get human_url method onto the worksheet, so that sheets within a spreadsheet could be created, populated and then redirected to from a single url.

I couldn't find a clean way to get the gid for a worksheet, so I had to parse it out of the spreadsheet feed xml data.  It searches within this xml for the sheet title, so this requires that the sheets have unique titles.
