### PR TITLE
Add worksheet_by_gid

### DIFF
--- a/lib/google_drive/worksheet.rb
+++ b/lib/google_drive/worksheet.rb
@@ -17,13 +17,14 @@ module GoogleDrive
 
         include(Util)
 
-        def initialize(session, spreadsheet, cells_feed_url, title = nil, updated = nil) #:nodoc:
-          
+        def initialize(session, spreadsheet, cells_feed_url, title = nil, updated = nil, gid = nil) #:nodoc:
+
           @session = session
           @spreadsheet = spreadsheet
           @cells_feed_url = cells_feed_url
           @title = title
           @updated = updated
+          @gid = gid
 
           @cells = nil
           @input_values = nil
@@ -199,6 +200,11 @@ module GoogleDrive
         def updated
           reload() if !@updated
           return @updated
+        end
+
+        # Gid of the worksheet if provided by the api.
+        def gid
+          return @gid
         end
 
         # Updates title of the worksheet.


### PR DESCRIPTION
Thanks so much for this gem. I added a new method, described below.

My example spreadsheet has a worksheet with a gid of 1836968288 - visible as a URL param:
https://docs.google.com/spreadsheets/d/1NfC3a5k0qsS5qxv10v2P88VzqFReyCi-rI8LIB4qvYg/edit#gid=1836968288

This gid also appears in link hrefs in the worksheets feed.
https://spreadsheets.google.com/feeds/worksheets/1NfC3a5k0qsS5qxv10v2P88VzqFReyCi-rI8LIB4qvYg/private/full
The css selector might look like:
entry link[href*="gid=1836968288"]

I've added support for getting this worksheet using:
session.spreadsheet_by_key('1NfC3a5k0qsS5qxv10v2P88VzqFReyCi-rI8LIB4qvYg').worksheet_by_gid(1836968288)

I thought this might be useful for others. (I've built a local gem to use it myself for now.)
