### PR TITLE
Allow optional user and password for proxy.

### DIFF
--- a/lib/google_drive/basic_fetcher.rb
+++ b/lib/google_drive/basic_fetcher.rb
@@ -15,7 +15,7 @@ module GoogleDrive
             @proxy = proxy
           elsif ENV["http_proxy"] && !ENV["http_proxy"].empty?
             proxy_url = URI.parse(ENV["http_proxy"])
-            @proxy = Net::HTTP.Proxy(proxy_url.host, proxy_url.port)
+            @proxy = Net::HTTP.Proxy(proxy_url.host, proxy_url.port, proxy_url.user, proxy_url.password)
           else
             @proxy = Net::HTTP
           end


### PR DESCRIPTION
Reference:
http://www.ruby-doc.org/stdlib-2.1.3/libdoc/net/http/rdoc/Net/HTTP.html#method-c-Proxy
