### PR TITLE
Open "application/vnd.google-apps.form" as Spreadsheet instead of generic File.

### DIFF
--- a/lib/google_drive/session.rb
+++ b/lib/google_drive/session.rb
@@ -360,6 +360,8 @@ module GoogleDrive
               return Collection.new(self, api_file)
             when "application/vnd.google-apps.spreadsheet"
               return Spreadsheet.new(self, api_file)
+            when "application/vnd.google-apps.form"
+              return Spreadsheet.new(self, api_file)
             else
               return File.new(self, api_file)
           end


### PR DESCRIPTION
Forms powered by Google Spreadsheets are accessible over the Spreadsheets API. We have a few API clients that rely on this behavior (aggregating data in some of our hand-edited spreadsheets along with some data in user-facing Google Forms).

I *think* this worked in some of our older code with `google-spreadsheet-ruby` (maybe it wasn't checking MIME, or Google hadn't changed the MIME at that point).

Anyway, this allows us to access a Form by `spreadsheet_by_key` without getting

    GoogleDrive::Error - The file with the ID is not a spreadsheet:

…allowing us to use the Spreadsheet API (`.worksheets[0].rows` etc…) to retrieve the data in that resultant spreadsheet. *Note:* Haven't tested the write portions (`ws.save()` etc) of the API.