### PR TITLE
Update README file with instructions about Google Client ID type. [Fixes #133]

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -17,7 +17,7 @@ I recommend to switch to the new API. But if you somehow want to continue using 
 
 = How to use
 
-First, follow "Create a client ID and client secret" in {this page}[https://developers.google.com/drive/web/auth/web-server] to get a client ID and client secret for OAuth.
+First, you need to create a project in the Google Developers Console. Follow "Create a client ID and client secret" in {this page}[https://developers.google.com/drive/web/auth/web-server] to get a client ID and client secret for OAuth. When selecting Client ID type make sure you select "Installed application" as it the only type that displays an auth code to copy and paste.
 
 Example to read/write files in Google Drive:
 


### PR DESCRIPTION
Added explanation to README file that you have to select "Installed application" as Client ID type when setting up project on Google.