### PR TITLE
Force use of Minitest 4 to avoid getting conflicts with Minitest 5

### DIFF
--- a/google_drive.gemspec
+++ b/google_drive.gemspec
@@ -21,5 +21,6 @@ Gem::Specification.new do |s|
   s.add_dependency("oauth2", [">= 0.5.0"])
   s.add_dependency("google-api-client", [">= 0.7.0"])
   s.add_development_dependency("rake", [">= 0.8.0"])
+  s.add_development_dependency("minitest", ["~> 4"])
 
 end


### PR DESCRIPTION
**Problem:** 
Ruby's stdlib test/unit implementation is backed by Minitest 4 and doesn't support Minitest 5. *google-api-client* dependency imports *Active Support* using "optimistic versioning" (http://guides.rubygems.org/patterns/#pessimistic_version_constraint), i.e: `s.add_runtime_dependency 'activesupport', '>= 3.2'`. This cause problems, because active support 4.2 requires minitest 5 to work, and it creates conflicts with ruby's stdlib test/unit.

**How to reproduce:** 
1. Delete `Gemfile.lock` from your own copy of google-drive-ruby repository
2. Run `bundle install` and check that it is using rails >= 4.2 and minitest >= 5
4. Run `rake test`

You will receive this error: `MiniTest::Unit::TestCase is now Minitest::Test. From /home/matyf/.rvm/rubies/ruby-1.9.3-p551/lib/ruby/1.9.1/test/unit/testcase.rb:8:in '<module:Unit>'`

I'm using *Ruby 1.9.3-p551*

**Solution:** 
Fix Minitest version to 4.x in `google_drive.gemspec`