### PR TITLE
We shouldn't override ruby core method singleton_class

### DIFF
--- a/lib/google_drive/util.rb
+++ b/lib/google_drive/util.rb
@@ -153,14 +153,8 @@ module GoogleDrive
           return new_params
         end
 
-        def singleton_class(obj)
-          class << obj
-            return self
-          end
-        end
-
         def delegate_api_methods(obj, api_obj, exceptions = [])
-          sc = singleton_class(obj)
+          sc = obj.singleton_class
           names = api_obj.class.keys.keys - exceptions.map(&:to_s)
           names.each() do |name|
             sc.__send__(:define_method, name) do


### PR DESCRIPTION
`singleton_class` is a [core ruby method](http://ruby-doc.org/core-1.9.2/Object.html#method-i-singleton_class), why overwrite it? Right now having it overwritten breaks some rspec mocking functionality.