### PR TITLE
Enable to set the optional parameters for the insert API

### DIFF
--- a/lib/google_drive/acl.rb
+++ b/lib/google_drive/acl.rb
@@ -33,6 +33,13 @@ module GoogleDrive
         # :scope_type, :scope and :role. See GoogleDrive::AclEntry#scope_type and
         # GoogleDrive::AclEntry#role for the document of the fields.
         #
+        # Also you can pass the second hash argument +options+, which specifies
+        # optional query parameters for the API.
+        # Possible keys of +options+ are,
+        # * :emailMessage  -- A custom message to include in notification emails
+        # * :sendNotificationEmails  -- Whether to send notification emails
+        #   when sharing to users or groups.
+        #
         # NOTE: This sends email to the new people.
         #
         # e.g.

--- a/lib/google_drive/acl.rb
+++ b/lib/google_drive/acl.rb
@@ -47,16 +47,20 @@ module GoogleDrive
         #   # Anyone who knows the link can read.
         #   spreadsheet.acl.push(
         #       {:type => "anyone", :withLink => true, :role => "reader"})
+        #   # Set ACL without sending notification emails
+        #   spreadsheet.acl.push(
+        #       {:type => "user", :value => "example2@gmail.com", :role => "reader"},
+        #       {:sendNotificationEmails => false})
         #
         # See here for parameter detais:
         # https://developers.google.com/drive/v2/reference/permissions/insert
-        def push(params_or_entry)
+        def push(params_or_entry, options = {})
           entry = params_or_entry.is_a?(AclEntry) ? params_or_entry : AclEntry.new(params_or_entry)
           new_permission = @session.drive.permissions.insert.request_schema.new(entry.params)
           api_result = @session.execute!(
               :api_method => @session.drive.permissions.insert,
               :body_object => new_permission,
-              :parameters => { "fileId" => @file.id })
+              :parameters => options.merge({ "fileId" => @file.id }))
           new_entry = AclEntry.new(api_result.data, self)
           @entries.push(new_entry)
           return new_entry


### PR DESCRIPTION
This change enables to set the optional query parameters emailMessage and sendNotificationEmails.
(See https://developers.google.com/drive/v2/reference/permissions/insert)

You can specify these parameters as follows:

```ruby
# Set the ACL without sending notification emails
spreadsheet.acl.push(
      {:type => "user", :value => "example2@gmail.com", :role => "reader"},
      {:sendNotificationEmails => false})

# Set the ACL with sending notification emails and with specifying the message
spreadsheet.acl.push(
      {:type => "user", :value => "example2@gmail.com", :role => "reader"},
      {:sendNotificationEmails => true, : emailMessage => "I've shared this document"})
```

I agree that passing two hash arguments to a method doesn't seem very smart, but this won't break the compatibility. So I think this is reasonable solution.

Could you merge this change?