### PR TITLE
Specify minitest as a development dependency gem

### DIFF
--- a/google_drive.gemspec
+++ b/google_drive.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   # TODO Switch to 0.9 API once it is released:
   #   https://github.com/google/google-api-ruby-client/blob/master/MIGRATING.md
   s.add_dependency("google-api-client", [">= 0.7.0", "< 0.9"])
-  s.add_dependency("minitest", [">= 5.1.0"])
+  s.add_development_dependency("minitest", [">= 5.1.0"])
   s.add_development_dependency("rake", [">= 0.8.0"])
 
 end


### PR DESCRIPTION
I think `minitest` is only used by test.
It may be a development dependency gem.