### PR TITLE
Adds a prepend method to the Worksheet class

### DIFF
--- a/lib/google_drive/worksheet.rb
+++ b/lib/google_drive/worksheet.rb
@@ -19,7 +19,7 @@ module GoogleDrive
         include(Util)
 
         def initialize(session, spreadsheet, worksheet_feed_entry) #:nodoc:
-          
+
           @session = session
           @spreadsheet = spreadsheet
           set_worksheet_feed_entry(worksheet_feed_entry)
@@ -29,7 +29,7 @@ module GoogleDrive
           @numeric_values = nil
           @modified = Set.new()
           @list = nil
-          
+
         end
 
         # Nokogiri::XML::Element object of the <entry> element in a worksheets feed.
@@ -105,7 +105,7 @@ module GoogleDrive
         end
 
         # Updates content of the cell.
-        # Arguments in the bracket must be either (row number, column number) or cell name. 
+        # Arguments in the bracket must be either (row number, column number) or cell name.
         # Note that update is not sent to the server until you call save().
         # Top-left cell is [1, 1].
         #
@@ -175,7 +175,7 @@ module GoogleDrive
           reload_cells() if !@cells
           return @numeric_values[[row, col]]
         end
-        
+
         # Row number of the bottom-most non-empty row.
         def num_rows
           reload_cells() if !@cells
@@ -232,6 +232,13 @@ module GoogleDrive
           return @cells
         end
 
+        # Easily Gives the ability to prepend a row
+        def prepend(array_to_prepend, start_row = nil)
+          row = start_row || 1
+          create_empty_row(row)
+          update_cells(start_row, 1, array_to_prepend)
+        end
+
         # An array of spreadsheet rows. Each row contains an array of
         # columns. Note that resulting array is 0-origin so:
         #
@@ -254,7 +261,7 @@ module GoogleDrive
 
         # Saves your changes made by []=, etc. to the server.
         def save()
-          
+
           sent = false
 
           if @meta_modified
@@ -349,9 +356,9 @@ module GoogleDrive
             sent = true
 
           end
-          
+
           return sent
-          
+
         end
 
         # Calls save() and reload().
@@ -377,7 +384,7 @@ module GoogleDrive
           return @worksheet_feed_entry.css(
             "link[rel='http://schemas.google.com/spreadsheets/2006#listfeed']")[0]["href"]
         end
-        
+
         # Provides access to cells using column names, assuming the first row contains column
         # names. Returned object is GoogleDrive::List which you can use mostly as
         # Array of Hash.
@@ -393,7 +400,7 @@ module GoogleDrive
         def list
           return @list ||= List.new(self)
         end
-        
+
         # Returns a [row, col] pair for a cell name string.
         # e.g.
         #   worksheet.cell_name_to_row_col("C2")  #=> [2, 3]
@@ -420,7 +427,7 @@ module GoogleDrive
           fields[:title] = @title if @title
           return "\#<%p %s>" % [self.class, fields.map(){ |k, v| "%s=%p" % [k, v] }.join(", ")]
         end
-        
+
       private
 
         def set_worksheet_feed_entry(entry)
@@ -431,7 +438,7 @@ module GoogleDrive
         end
 
         def reload_cells()
-          
+
           doc = @session.request(:get, self.cells_feed_url)
           @max_rows = doc.css("gs|rowCount").text.to_i()
           @max_cols = doc.css("gs|colCount").text.to_i()
@@ -470,7 +477,24 @@ module GoogleDrive
                 "Arguments must be either one String or two Integer's, but are %p" % [args])
           end
         end
-        
+
+        def create_empty_row(start_row)
+          full_array = self.rows
+          column_length = full_array.first.length
+          row_length = full_array.length
+          unless row_length < start_row
+            if row_length == start_row
+              rows_array = Array.new << full_array.last
+            else
+              rows_array = self.rows[(start_row - 1)..row_length]
+            end
+            empty_row = column_length.times.map {""}
+            a = Array.new rows_array
+            a = a.unshift(empty_row)
+            self.update_cells(start_row, 1, a)
+          end
+        end
+
     end
-    
+
 end


### PR DESCRIPTION
I have a Production application using this project to read/write to a shared spreadsheet. Basically every night I add new entries to a spreadsheet. I had to write some code around this gem to make this work on my project but I figured I would write it up in a pull request if its something that would benefit the community. 

Creates two methods in the GoogleDrive::Worksheet class. This introduces the ability to pass in data and a selected row to prepend on a worksheet object.

If this is useful I am more then willing to write up specs. 

#### Example: 

```ruby
@worksheet.prepend([1,2,3,4,5], start_row: 2)
```

Cheers
