### PR TITLE
Non file-based saved session

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ test/account.yaml
 .rvmrc
 Gemfile.lock
 .idea
+/tmp/

--- a/google_drive.gemspec
+++ b/google_drive.gemspec
@@ -24,5 +24,6 @@ Gem::Specification.new do |s|
   s.add_dependency("google-api-client", [">= 0.7.0", "< 0.9"])
   s.add_development_dependency("test-unit", [">= 3.0.0"])
   s.add_development_dependency("rake", [">= 0.8.0"])
+  s.add_development_dependency("rspec-mocks", [">= 3.4.0"])
 
 end

--- a/lib/google_drive.rb
+++ b/lib/google_drive.rb
@@ -105,9 +105,25 @@ module GoogleDrive
     #
     # If the file doesn't exist or client ID/secret are not given in the file, the default client
     # ID/secret embedded in the library is used.
+    #
+    # You can also provide a config object that must respond to:
+    #   client_id
+    #   client_secret
+    #   refesh_token
+    #   refresh_token=
+    #   scope
+    #   scope=
+    #   save
     def self.saved_session(
-        path = nil, proxy = nil, client_id = nil, client_secret = nil)
-      config = Config.new(path || ENV['HOME'] + '/.ruby_google_drive.token')
+        path_or_config = nil, proxy = nil, client_id = nil, client_secret = nil)
+      config = case path_or_config
+      when String
+        Config.new(path_or_config)
+      when nil
+        Config.new(ENV['HOME'] + '/.ruby_google_drive.token')
+      else
+        path_or_config
+      end
 
       config.scope ||= [
           'https://www.googleapis.com/auth/drive',

--- a/test/fixtures/config_minimal.json
+++ b/test/fixtures/config_minimal.json
@@ -1,0 +1,4 @@
+{
+  "client_id": "some client id",
+  "client_secret": "some client secret"
+}

--- a/test/fixtures/config_with_refresh.json
+++ b/test/fixtures/config_with_refresh.json
@@ -1,0 +1,5 @@
+{
+  "client_id": "some id2",
+  "client_secret": "some secret2",
+  "refresh_token": "already-refresh"
+}

--- a/test/run_test.sh
+++ b/test/run_test.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
 
 rvm 1.9.3,2.2.1 do bundle exec ruby test/test_google_drive.rb
+rvm 1.9.3,2.2.1 do bundle exec ruby test/test_google_drive_mocked.rb

--- a/test/test_google_drive_mocked.rb
+++ b/test/test_google_drive_mocked.rb
@@ -1,3 +1,4 @@
+# The license of this source is "New BSD Licence"
 $LOAD_PATH.unshift(File.dirname(__FILE__) + "/../lib")
 require "yaml"
 

--- a/test/test_google_drive_mocked.rb
+++ b/test/test_google_drive_mocked.rb
@@ -1,0 +1,110 @@
+$LOAD_PATH.unshift(File.dirname(__FILE__) + "/../lib")
+require "yaml"
+
+require "rubygems"
+require "bundler/setup"
+require "test/unit"
+require "rspec/mocks"
+
+require "google_drive"
+require 'google/api_client'
+
+class TestGoogleDriveMocked < Test::Unit::TestCase
+  include ::RSpec::Mocks::ExampleMethods
+  CONFIG_FILEPATH = File.expand_path("../../tmp/config.json", __FILE__)
+
+  def setup
+    FileUtils.rm_f(CONFIG_FILEPATH)
+    ::RSpec::Mocks.setup
+  end
+
+  def teardown
+    ::RSpec::Mocks.verify if passed?
+  ensure
+    ::RSpec::Mocks.teardown
+  end
+
+  def swallow_stderr
+    require "stringio"
+    old_stderr = STDERR
+    $stderr = StringIO.new
+    yield
+  ensure
+    $stderr = old_stderr
+  end
+
+  def mocked_auth
+    double("Auth").tap do |auth|
+      allow(auth).to receive(:client_id=)
+      allow(auth).to receive(:client_secret=)
+      allow(auth).to receive(:scope=)
+      allow(auth).to receive(:redirect_uri=)
+      allow(auth).to receive(:fetch_access_token!)
+    end
+  end
+
+  def expect_mocked_google_client_to_return_auth_object
+    mocked_auth.tap do |auth|
+      client = instance_double(Google::APIClient)
+      expect(Google::APIClient).to receive(:new).and_return(client)
+      expect(client).to receive(:authorization).and_return(auth)
+      expect(GoogleDrive).to receive(:login_with_oauth).with(client)
+    end
+  end
+
+  def test_works_with_nothing
+    auth = expect_mocked_google_client_to_return_auth_object
+    refresh_token = 'some_token'
+    config = GoogleDrive::Config.new(CONFIG_FILEPATH)
+    expect(GoogleDrive::Config).to receive(:new).with(ENV['HOME'] + '/.ruby_google_drive.token').and_return(config)
+    allow(config).to receive(:refresh_token).and_return(refresh_token)
+    expect(auth).to receive(:refresh_token=).with(refresh_token)
+    GoogleDrive.saved_session
+  end
+
+  def test_works_with_explicit_path_without_refresh_token()
+    src_path = File.expand_path("../fixtures/config_minimal.json", __FILE__)
+    FileUtils.cp(src_path, CONFIG_FILEPATH)
+
+    auth = expect_mocked_google_client_to_return_auth_object
+    retrieved_refresh_token = "my-retrieved-refresh"
+    expect(auth).to receive(:refresh_token).and_return(retrieved_refresh_token)
+    expect(auth).to receive(:authorization_uri).and_return('something')
+    allow(STDIN).to receive(:gets) { 'some-code' }
+    expect(auth).to receive(:code=).and_return('some-code')
+
+    swallow_stderr do
+      GoogleDrive.saved_session(CONFIG_FILEPATH)
+    end
+    assert_file_contains(CONFIG_FILEPATH,
+        client_id: "some client id",
+        client_secret: "some client secret",
+        refresh_token: retrieved_refresh_token,
+    )
+
+  end
+
+  def test_works_with_explicit_path_with_refresh_token()
+    src_path = File.expand_path("../fixtures/config_with_refresh.json", __FILE__)
+    FileUtils.cp(src_path, CONFIG_FILEPATH)
+
+    auth = expect_mocked_google_client_to_return_auth_object
+    configs_refresh_token = "already-refresh"
+    expect(auth).to receive(:refresh_token=).and_return(configs_refresh_token)
+
+    GoogleDrive.saved_session(CONFIG_FILEPATH)
+    assert_file_contains(CONFIG_FILEPATH,
+        client_id: "some id2",
+        client_secret: "some secret2",
+        refresh_token: configs_refresh_token,
+    )
+
+  end
+
+  def assert_file_contains(path, values)
+    json = JSON.parse(::File.read(path))
+    values.each_pair do |k, v|
+      assert_equal(json[k.to_s], v, k.to_s)
+    end
+  end
+end


### PR DESCRIPTION
The `GoogleDrive.saved_session` is very useful for two-legged-auth set up, however I'd like to be able to have a saved_session that can be pulled from/saved to something other than a file (e.g. a database). To do this, I suggest having the first argument being either string/nil (as currently) or an object that responds to save, and the specific attributes:

* client_id
* client_secret
* refesh_token
* refresh_token=
* scope
* scope=
* save
