### PR TITLE
Support google-api-client 0.11.0

### DIFF
--- a/google_drive.gemspec
+++ b/google_drive.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
 
   s.add_dependency('nokogiri', ['>= 1.5.3', '< 2.0.0'])
-  s.add_dependency('google-api-client', ['>= 0.9.0', '< 1.0.0'])
+  s.add_dependency('google-api-client', ['>= 0.11.0', '< 1.0.0'])
   s.add_dependency('googleauth', ['>= 0.5.0', '< 1.0.0'])
   s.add_development_dependency('test-unit', ['>= 3.0.0', '< 4.0.0'])
   s.add_development_dependency('rake', ['>= 0.8.0'])

--- a/lib/google_drive/api_client_fetcher.rb
+++ b/lib/google_drive/api_client_fetcher.rb
@@ -22,17 +22,9 @@ module GoogleDrive
       @drive.authorization = authorization
       # Make the timeout virtually infinite because some of the operations (e.g., uploading a large file)
       # can take very long.
-      if @drive.request_options.respond_to?(:timeout_sec=)
-        # google-api-client 0.9.x, 0.10.x
-        @drive.request_options.timeout_sec      = 100_000_000
-        @drive.request_options.open_timeout_sec = 100_000_000
-      else
-        # google-api-client 0.11.0 or later
-        # see also: https://github.com/google/google-api-ruby-client/blob/0.11.0/MIGRATING.md#timeouts
-        @drive.client_options.open_timeout_sec = 100_000_000
-        @drive.client_options.read_timeout_sec = 100_000_000
-        @drive.client_options.send_timeout_sec = 100_000_000
-      end
+      @drive.client_options.open_timeout_sec = 100_000_000
+      @drive.client_options.read_timeout_sec = 100_000_000
+      @drive.client_options.send_timeout_sec = 100_000_000
     end
 
     attr_reader(:drive)

--- a/lib/google_drive/api_client_fetcher.rb
+++ b/lib/google_drive/api_client_fetcher.rb
@@ -22,8 +22,17 @@ module GoogleDrive
       @drive.authorization = authorization
       # Make the timeout virtually infinite because some of the operations (e.g., uploading a large file)
       # can take very long.
-      @drive.request_options.timeout_sec = 100_000_000
-      @drive.request_options.open_timeout_sec = 100_000_000
+      if @drive.request_options.respond_to?(:timeout_sec=)
+        # google-api-client 0.9.x, 0.10.x
+        @drive.request_options.timeout_sec      = 100_000_000
+        @drive.request_options.open_timeout_sec = 100_000_000
+      else
+        # google-api-client 0.11.0 or later
+        # see also: https://github.com/google/google-api-ruby-client/blob/0.11.0/MIGRATING.md#timeouts
+        @drive.client_options.open_timeout_sec = 100_000_000
+        @drive.client_options.read_timeout_sec = 100_000_000
+        @drive.client_options.send_timeout_sec = 100_000_000
+      end
     end
 
     attr_reader(:drive)


### PR DESCRIPTION
Fixes #253

Timeout options in google-api-client 0.11.0 have been moved from request_options to client_options.

see also:
- https://github.com/google/google-api-ruby-client/blob/0.11.0/MIGRATING.md#timeouts
- https://github.com/google/google-api-ruby-client/blob/0.11.0/CHANGELOG.md#0110
