### PR TITLE
Add upload to remote folder method

### DIFF
--- a/lib/google_drive/session.rb
+++ b/lib/google_drive/session.rb
@@ -415,6 +415,37 @@ module GoogleDrive
         {content_type: default_content_type}.merge(params))
     end
 
+    # Uploads a local file to remote folder.
+    # Returns a GoogleSpreadsheet::File object.
+    #
+    # e.g.
+    #   # Uploads a text file and converts to a Google Docs document:
+    #   session.upload_from_file_to_folder("/path/to/hoge.txt","remote_folder_id")
+    #
+    #   # Uploads without conversion:
+    #   session.upload_from_file_to_folder("/path/to/hoge.txt", "remote_folder_id", "Hoge", :convert => false)
+    #
+    #   # Uploads with explicit content type:
+    #   session.upload_from_file_to_folder("/path/to/hoge", "remote_folder_id", "Hoge", :content_type => "text/plain")
+    #
+    #   # Uploads a text file and converts to a Google Spreadsheet:
+    #   session.upload_from_file_to_folder("/path/to/hoge.csv", "remote_folder_id", "Hoge")
+    #   session.upload_from_file_to_folder("/path/to/hoge", "remote_folder_id", "Hoge", :content_type => "text/csv")
+    def upload_from_file_to_folder(path, remote_folder_id, title = nil, params = {})
+      parents = [remote_folder_id]
+      file_name = ::File.basename(path)
+      default_content_type =
+        EXT_TO_CONTENT_TYPE[::File.extname(file_name).downcase] ||
+        'application/octet-stream'
+      upload_from_source(
+        path,
+        title || file_name,
+        {
+          content_type: default_content_type,
+          parents: parents,
+        }.merge(params))
+    end
+
     # Uploads a file. Reads content from +io+.
     # Returns a GoogleDrive::File object.
     def upload_from_io(io, title = 'Untitled', params = {})
@@ -508,6 +539,8 @@ module GoogleDrive
       content_type = api_params[:content_type]
       if params[:convert_mime_type]
         file_metadata[:mime_type] = params[:convert_mime_type]
+      elsif params[:parents]
+        file_metadata[:parents] = params[:folder_id]
       elsif params.fetch(:convert, true) && IMPORTABLE_CONTENT_TYPE_MAP.key?(content_type)
         file_metadata[:mime_type] = IMPORTABLE_CONTENT_TYPE_MAP[content_type]
       end

--- a/test/test_file3.txt
+++ b/test/test_file3.txt
@@ -1,0 +1,3 @@
+Yet another test file.
+
+This file is upload to test folder.

--- a/test/test_google_drive.rb
+++ b/test/test_google_drive.rb
@@ -222,6 +222,15 @@ class TestGoogleDrive < Test::Unit::TestCase
     assert { file.title == test_file_title }
     assert { file.available_content_types == ["text/plain"] }
     assert { file.download_to_string == File.read(test_file_path) }
+    
+    # Uploads a test file to folder.
+    test_file_path = File.join(File.dirname(__FILE__), 'test_file.txt')
+    file = session.upload_from_file_to_foler(test_file_path, test_file_title, test_remote_folder, convert: false)
+    assert { file.is_a?(GoogleDrive::File) }
+    assert { file.title == test_file_title }
+    assert { file.available_content_types == ["text/plain"] }
+    assert { file.download_to_string == File.read(test_file_path) }
+
 
     # Updates the content of the file.
     test_file2_path = File.join(File.dirname(__FILE__), 'test_file2.txt')

--- a/test/test_google_drive.rb
+++ b/test/test_google_drive.rb
@@ -16,6 +16,29 @@ class TestGoogleDrive < Test::Unit::TestCase
 
   @@session = nil
 
+  def get_folder_id
+    folder_id_path = File.join(File.dirname(__FILE__), 'folder_id.yaml')
+    if File.exist?(folder_id_path)
+      folder_id_conf = YAML.load_file(folder_id_path)
+      begin
+        folder_id = folder_id_conf["folder_id"]
+        return folder_id
+      rescue
+        raise("folder_id.yaml is not valid. Delete or rewrite it.")
+      end
+    else
+      while true
+        puts "Please input your Google Drive's test folder id:"
+        folder_id = gets.chomp
+        if !folder_id.empty?
+          fh = { "folder_id" => folder_id}
+          YAML.dump(fh,File.open(folder_id_path,'w'))
+          return folder_id
+        end
+      end
+    end
+  end
+
   def test_spreadsheet_online
     session = get_session
 
@@ -192,6 +215,7 @@ class TestGoogleDrive < Test::Unit::TestCase
     test_collection_title = "#{PREFIX}collection"
     test_file_title = "#{PREFIX}file.txt"
     test_file2_title = "#{PREFIX}file2.txt"
+    test_file3_title = "#{PREFIX}file3.txt"
 
     # Removes test files/collections in the previous run in case the previous run failed.
     for title in [test_file_title, test_collection_title]
@@ -222,15 +246,15 @@ class TestGoogleDrive < Test::Unit::TestCase
     assert { file.title == test_file_title }
     assert { file.available_content_types == ["text/plain"] }
     assert { file.download_to_string == File.read(test_file_path) }
-    
-    # Uploads a test file to folder.
-    test_file_path = File.join(File.dirname(__FILE__), 'test_file.txt')
-    file = session.upload_from_file_to_foler(test_file_path, test_file_title, test_remote_folder, convert: false)
-    assert { file.is_a?(GoogleDrive::File) }
-    assert { file.title == test_file_title }
-    assert { file.available_content_types == ["text/plain"] }
-    assert { file.download_to_string == File.read(test_file_path) }
 
+    # Uploads a test file to folder.
+    test_file3_path = File.join(File.dirname(__FILE__), 'test_file3.txt')
+    test_remote_folder = get_folder_id
+    file3 = session.upload_from_file_to_folder(test_file3_path, test_remote_folder, test_file3_title, convert: false)
+    assert { file3.is_a?(GoogleDrive::File) }
+    assert { file3.title == test_file3_title }
+    assert { file3.available_content_types == ["text/plain"] }
+    assert { file3.download_to_string == File.read(test_file3_path) }
 
     # Updates the content of the file.
     test_file2_path = File.join(File.dirname(__FILE__), 'test_file2.txt')


### PR DESCRIPTION
Add upload to Google Drive's remote folder method.

method name is `upload_from_file_to_folder` .
Added remote_folder_id as the second argument to upload_from_file.

I Added TestCase as `# Uploads a test file to folder.`  to under `#Uploads a test file` .
This TestCase is must to have remote folder id.So I added get test user's folder id method `get_folder_id`.
This method is get folder id from user input,and save to `folder_id.yaml` and use in TestCase.

