### PR TITLE
Add support for uploading to team drives

### DIFF
--- a/lib/google_drive/collection.rb
+++ b/lib/google_drive/collection.rb
@@ -15,13 +15,13 @@ module GoogleDrive
 
     # Adds the given GoogleDrive::File to the collection.
     def add(file)
-      @session.drive.update_file(file.id, add_parents: self.id, fields: '')
+      @session.drive.update_file(file.id, add_parents: self.id, fields: '', supports_team_drives: true)
       nil
     end
 
     # Removes the given GoogleDrive::File from the collection.
     def remove(file)
-      @session.drive.update_file(file.id, remove_parents: self.id, fields: '')
+      @session.drive.update_file(file.id, remove_parents: self.id, fields: '', supports_team_drives: true)
     end
 
     # Creates a sub-collection with given title. Returns GoogleDrive::Collection object.
@@ -31,7 +31,7 @@ module GoogleDrive
         mime_type: 'application/vnd.google-apps.folder',
         parents: [self.id],
       }
-      file = @session.drive.create_file(file_metadata, fields: '*')
+      file = @session.drive.create_file(file_metadata, fields: '*', supports_team_drives: true)
       @session.wrap_api_file(file)
     end
 

--- a/lib/google_drive/session.rb
+++ b/lib/google_drive/session.rb
@@ -497,6 +497,7 @@ module GoogleDrive
         upload_source: source,
         content_type: 'application/octet-stream',
         fields: '*',
+        supports_team_drives: true
       }
       for k, v in params
         if ![:convert, :convert_mime_type, :parents].include?(k)


### PR DESCRIPTION
This is to address the following error received when uploading a file to a Team Drive  folder:
'Google::Apis::ClientError: notFound: File not found: <file_id>'.