### PR TITLE
allow google-api-client v0.21.x

### DIFF
--- a/google_drive.gemspec
+++ b/google_drive.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
 
   s.add_dependency('nokogiri', ['>= 1.5.3', '< 2.0.0'])
-  s.add_dependency('google-api-client', ['>= 0.11.0', '< 0.20.0'])
+  s.add_dependency('google-api-client', ['>= 0.11.0', '< 0.22.0'])
   s.add_dependency('googleauth', ['>= 0.5.0', '< 1.0.0'])
   s.add_development_dependency('test-unit', ['>= 3.0.0', '< 4.0.0'])
   s.add_development_dependency('rake', ['>= 0.8.0'])


### PR DESCRIPTION
updates the version constraint of 'google-api-client'.
no breaking changes to the drive api between v0.19 and v0.21.

https://github.com/google/google-api-ruby-client/blob/master/CHANGELOG.md