### PR TITLE
Added collection_by_id to GoogleDrive::Session

### DIFF
--- a/lib/google_drive/file.rb
+++ b/lib/google_drive/file.rb
@@ -44,11 +44,6 @@ module GoogleDrive
       @acl = Acl.new(@session, self) if @acl
     end
 
-    # Key of the spreadsheet.
-    def key
-      id
-    end
-    
     # Returns resource_type + ":" + id.
     def resource_id
       format('%s:%s', resource_type, id)

--- a/lib/google_drive/file.rb
+++ b/lib/google_drive/file.rb
@@ -44,6 +44,11 @@ module GoogleDrive
       @acl = Acl.new(@session, self) if @acl
     end
 
+    # Key of the spreadsheet.
+    def key
+      id
+    end
+    
     # Returns resource_type + ":" + id.
     def resource_id
       format('%s:%s', resource_type, id)

--- a/lib/google_drive/session.rb
+++ b/lib/google_drive/session.rb
@@ -418,23 +418,23 @@ module GoogleDrive
 
     alias folder_by_url collection_by_url
 
-    # Returns GoogleDrive::Collection with given +key+.
+    # Returns GoogleDrive::Collection with given +id+.
     #
     # e.g.
-    #   # https://drive.google.com/drive/u/2/folders/1rPPuzAew4tO3ORc88Vz1JscPCcnrX7-J
-    #   session.collection_by_key("1rPPuzAew4tO3ORc88Vz1JscPCcnrX7-J")
-    def collection_by_key(key)
-      file = file_by_id(key)
+    #   # https://drive.google.com/drive/folders/1rPPuzAew4tO3ORc88Vz1JscPCcnrX7-J
+    #   session.collection_by_id("1rPPuzAew4tO3ORc88Vz1JscPCcnrX7-J")
+    def collection_by_id(id)
+      file = file_by_id(id)
       unless file.is_a?(Collection)
         raise(
           GoogleDrive::Error,
-          format('The file with the ID is not a folder: %s', key)
+          format('The file with the ID is not a folder: %s', id)
         )
       end
       file
     end
 
-    alias folder_by_key collection_by_key
+    alias folder_by_id collection_by_id
 
     # Creates a top-level folder with given title. Returns GoogleDrive::Collection
     # object.

--- a/lib/google_drive/session.rb
+++ b/lib/google_drive/session.rb
@@ -418,6 +418,24 @@ module GoogleDrive
 
     alias folder_by_url collection_by_url
 
+    # Returns GoogleDrive::Collection with given +key+.
+    #
+    # e.g.
+    #   # https://drive.google.com/drive/u/2/folders/1rPPuzAew4tO3ORc88Vz1JscPCcnrX7-J
+    #   session.collection_by_key("1rPPuzAew4tO3ORc88Vz1JscPCcnrX7-J")
+    def collection_by_key(key)
+      file = file_by_id(key)
+      unless file.is_a?(Collection)
+        raise(
+          GoogleDrive::Error,
+          format('The file with the ID is not a folder: %s', key)
+        )
+      end
+      file
+    end
+
+    alias folder_by_key collection_by_key
+
     # Creates a top-level folder with given title. Returns GoogleDrive::Collection
     # object.
     def create_collection(title, file_properties = {})

--- a/lib/google_drive/spreadsheet.rb
+++ b/lib/google_drive/spreadsheet.rb
@@ -20,11 +20,6 @@ module GoogleDrive
 
     SUPPORTED_EXPORT_FORMAT = Set.new(%w[xlsx csv pdf])
 
-    # Key of the spreadsheet.
-    def key
-      id
-    end
-
     # URL of worksheet-based feed of the spreadsheet.
     def worksheets_feed_url
       format(

--- a/lib/google_drive/spreadsheet.rb
+++ b/lib/google_drive/spreadsheet.rb
@@ -20,6 +20,11 @@ module GoogleDrive
 
     SUPPORTED_EXPORT_FORMAT = Set.new(%w[xlsx csv pdf])
 
+    # Key of the spreadsheet.
+    def key
+      id
+    end
+    
     # URL of worksheet-based feed of the spreadsheet.
     def worksheets_feed_url
       format(

--- a/test/test_google_drive.rb
+++ b/test/test_google_drive.rb
@@ -228,7 +228,7 @@ class TestGoogleDrive < Test::Unit::TestCase
     )
     assert { collection3.files.empty? }
 
-    collection4 = session.collection_by_key(collection.key)
+    collection4 = session.collection_by_id(collection.id)
     assert { collection4.files.empty? }
 
     # Uploads a test file.

--- a/test/test_google_drive.rb
+++ b/test/test_google_drive.rb
@@ -397,7 +397,7 @@ class TestGoogleDrive < Test::Unit::TestCase
         )
       end
 
-      @@session = GoogleDrive::Session.from_config('config.json')
+      @@session = GoogleDrive::Session.from_config(config_path)
     end
     @@session
   end

--- a/test/test_google_drive.rb
+++ b/test/test_google_drive.rb
@@ -228,6 +228,9 @@ class TestGoogleDrive < Test::Unit::TestCase
     )
     assert { collection3.files.empty? }
 
+    collection4 = session.collection_by_key(collection.key)
+    assert { collection4.files.empty? }
+
     # Uploads a test file.
     test_file_path = File.join(File.dirname(__FILE__), 'test_file.txt')
     file = session.upload_from_file(
@@ -394,7 +397,7 @@ class TestGoogleDrive < Test::Unit::TestCase
         )
       end
 
-      @@session = GoogleDrive::Session.from_config(config_path)
+      @@session = GoogleDrive::Session.from_config('config.json')
     end
     @@session
   end


### PR DESCRIPTION
Added `collection_by_id` to GoogleDrive::Session because `collection_by_url` doesn't seem to work with custom domain gsuite collections.