### PR TITLE
Instantiate GoogleDrive::Sessions with Google API client options

### DIFF
--- a/lib/google_drive/api_client_fetcher.rb
+++ b/lib/google_drive/api_client_fetcher.rb
@@ -17,7 +17,7 @@ module GoogleDrive
       attr_reader(:code, :body)
     end
 
-    def initialize(authorization)
+    def initialize(authorization, client_options, request_options)
       @drive = Google::Apis::DriveV3::DriveService.new
       @drive.authorization = authorization
 
@@ -28,6 +28,18 @@ module GoogleDrive
       @drive.client_options.open_timeout_sec = t
       @drive.client_options.read_timeout_sec = t
       @drive.client_options.send_timeout_sec = t
+
+      if client_options
+        @drive.client_options.members.each do |name|
+          if !client_options[name].nil?
+            @drive.client_options[name] = client_options[name]
+          end
+        end
+      end
+
+      if request_options
+        @drive.request_options = @drive.request_options.merge(request_options)
+      end
     end
 
     attr_reader(:drive)

--- a/test/test_google_drive.rb
+++ b/test/test_google_drive.rb
@@ -341,7 +341,7 @@ class TestGoogleDrive < Test::Unit::TestCase
     file.acl.push(scope_type: 'anyone', with_key: true, role: 'reader')
     acl = file.acl(reload: true).sort_by { |e| e.scope_type }
     assert { acl.size == 2 }
-    
+
     assert { acl[0].scope_type == 'anyone' }
     assert { acl[0].with_key }
     assert { acl[0].role == 'reader' }
@@ -397,7 +397,11 @@ class TestGoogleDrive < Test::Unit::TestCase
         )
       end
 
-      @@session = GoogleDrive::Session.from_config(config_path)
+      @@session = GoogleDrive::Session.from_config(
+        config_path,
+        client_options: {transparent_gzip_decompression: true},
+        request_options: {retries: 3}
+      )
     end
     @@session
   end


### PR DESCRIPTION
 #### Summary
This PR allows callers to pass two new options to `GoogleDrive::Session.from_config`:
- `client_options`: a hash or an instance of `Google::Apis::ClientOptions`. These options are then applied to the client options of the `Session`'s underlying `Google::Apis::DriveV3::DriveService`. They control behavior like connection timeouts, use of gzip, etc. For a full list of properties which may be set, see https://github.com/google/google-api-ruby-client/blob/711dfb83b33c03535076917726956584d5c8bf9a/lib/google/apis/options.rb#L37-L58
- `request_options`: a hash or an instance of `Google::Apis::RequestOptions`. As with `client_options`, we pass these on to the underlying `DriveService`. Full list of properties: https://github.com/google/google-api-ruby-client/blob/711dfb83b33c03535076917726956584d5c8bf9a/lib/google/apis/options.rb#L60-L93

These same values can be passed to `from_service_account_key` and a few other factory methods as positional arguments.

 #### Motivation
I run a periodic query against a Google Sheet, and it sometimes fails with a `TransmissionError`, which is a bit vexing. The Internet suggests setting the number of retries in the `DriveService` instance's `request_options` to a higher number[0]. Doing this feels a bit more elegant than catching the `TransmissionError` myself.

 #### Testing
I added some client- and request options to the `Session` constructed in `test_google_drive.rb`, and then printed the `client_options` and `request_options` of the `DriveService` constructed here:

https://github.com/gimite/google-drive-ruby/blob/master/lib/google_drive/api_client_fetcher.rb#L20-L31 

[0] https://github.com/google/google-api-ruby-client/issues/589