### PR TITLE
Fix for spreadsheets containing full sheet charts

### DIFF
--- a/lib/google_drive/worksheet.rb
+++ b/lib/google_drive/worksheet.rb
@@ -638,8 +638,12 @@ module GoogleDrive
     def set_properties(properties)
       @properties = properties
       @title = @remote_title = properties.title
-      @max_rows = properties.grid_properties.row_count
-      @max_cols = properties.grid_properties.column_count
+      if properties.grid_properties.nil?
+        @max_rows = @max_cols = 0
+      else
+        @max_rows = properties.grid_properties.row_count
+        @max_cols = properties.grid_properties.column_count
+      end
       @meta_modified = false
     end
 


### PR DESCRIPTION
Since version 3.0.0, opening a spreadsheet containing a chart that has been moved to its own sheet fails. This is because the sheet with the chart has no grid_properties.

In 2.1.12 and lower, these sheets had row_count and column_count of 0. This change handles the error by checking if the grid_properties value is nil and using the behaviour from 2.1.12 if so.

Example spreadsheet: https://docs.google.com/spreadsheets/u/2/d/1JUGdhder88RWM4ngelQHRbFRu15pWe3q_Q2raLEJypg/edit

Example code:
```ruby
#!/usr/bin/env ruby
require 'google_drive'

session = GoogleDrive.saved_session("config.json")
Spreadsheet = session.spreadsheet_by_key("1hZTVj_n5sfD6tksa8YXfeODRH9W-6nKB9f1HGmh-b2Q")
Spreadsheet.worksheets
```

Trace of the error:
```
Traceback (most recent call last):
        6: from test.rb:7:in `<main>'
        5: from /home/dave/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/google_drive-3.0.1/lib/google_drive/spreadsheet.rb:53:in `worksheets'
        4: from /home/dave/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/google_drive-3.0.1/lib/google_drive/spreadsheet.rb:53:in `map'
        3: from /home/dave/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/google_drive-3.0.1/lib/google_drive/spreadsheet.rb:53:in `block in worksheets'
        2: from /home/dave/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/google_drive-3.0.1/lib/google_drive/spreadsheet.rb:53:in `new'
        1: from /home/dave/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/google_drive-3.0.1/lib/google_drive/worksheet.rb:60:in `initialize'
/home/dave/.rbenv/versions/2.5.1/lib/ruby/gems/2.5.0/gems/google_drive-3.0.1/lib/google_drive/worksheet.rb:641:in `set_properties': undefined method `row_count' for nil:NilClass (NoMethodError)
```