### PR TITLE
Updated google-api-client gem version

### DIFF
--- a/google_drive.gemspec
+++ b/google_drive.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
 
   s.add_dependency('nokogiri', ['>= 1.5.3', '< 2.0.0'])
-  s.add_dependency('google-api-client', ['>= 0.11.0', '< 0.29.0'])
+  s.add_dependency('google-api-client', ['>= 0.11.0', '< 0.31.0'])
   s.add_dependency('googleauth', ['>= 0.5.0', '< 1.0.0'])
   s.add_development_dependency('test-unit', ['>= 3.0.0', '< 4.0.0'])
   s.add_development_dependency('rake', ['>= 0.8.0'])


### PR DESCRIPTION
google-api-client 0.30.0 is released at May 27, 2019.
https://rubygems.org/gems/google-api-client
https://github.com/googleapis/google-api-ruby-client/blob/master/CHANGELOG.md