### PR TITLE
Bump nokogiri and gem version

### DIFF
--- a/google_drive.gemspec
+++ b/google_drive.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = 'google_drive'
-  s.version = '3.0.3'
+  s.version = '3.0.4'
   s.authors = ['Hiroshi Ichikawa']
   s.email = ['gimite+github@gmail.com']
   s.summary = 'A library to read/write files/spreadsheets in Google Drive/Docs.'
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.files = ['README.md'] + Dir['lib/**/*']
   s.require_paths = ['lib']
 
-  s.add_dependency('nokogiri', ['>= 1.5.3', '< 2.0.0'])
+  s.add_dependency('nokogiri', ['>= 1.10.4', '< 2.0.0'])
   s.add_dependency('google-api-client', ['>= 0.11.0', '< 0.31.0'])
   s.add_dependency('googleauth', ['>= 0.5.0', '< 1.0.0'])
   s.add_development_dependency('test-unit', ['>= 3.0.0', '< 4.0.0'])


### PR DESCRIPTION
Can we release a new version of this gem that incorporates the latest version of nokogiri please? They have released a new version with some important security updates.

See https://nvd.nist.gov/vuln/detail/CVE-2019-5477
and https://github.com/sparklemotion/nokogiri/issues/1915