### PR TITLE
Updated execute_paged method to fix pagination

### DIFF
--- a/lib/google_drive/session.rb
+++ b/lib/google_drive/session.rb
@@ -606,7 +606,8 @@ module GoogleDrive
 
       else
         parameters = (opts[:parameters] || {}).merge(page_token: nil)
-        (items,) = execute_paged!(opts.merge(parameters: parameters))
+        (items, page_token) = execute_paged!(opts.merge(parameters: parameters))
+        [items, page_token]
         items
       end
     end


### PR DESCRIPTION
As per documentation, to achieve pagination we can follow below example.
```
page_token = nil
begin
  (files, page_token) = session.files(page_token: page_token)
  p files
end while page_token
```
But Pagination is not working here as page_token is `nil`. so I made a modification to fix the issue.