### PR TITLE
Move to google-apis-drive/sheets gems

### DIFF
--- a/google_drive.gemspec
+++ b/google_drive.gemspec
@@ -14,7 +14,8 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
 
   s.add_dependency('nokogiri', ['>= 1.5.3', '< 2.0.0'])
-  s.add_dependency('google-api-client', '>= 0.11.0', '< 1.0.0')
+  s.add_dependency('google-apis-drive_v3', '>= 0.5.0', '< 1.0.0')
+  s.add_dependency('google-apis-sheets_v4', '>= 0.4.0', '< 1.0.0')
   s.add_dependency('googleauth', ['>= 0.5.0', '< 1.0.0'])
   s.add_development_dependency('test-unit', ['>= 3.0.0', '< 4.0.0'])
   s.add_development_dependency('rake', ['>= 0.8.0'])

--- a/test/test_google_drive.rb
+++ b/test/test_google_drive.rb
@@ -8,9 +8,6 @@ require 'test/unit'
 
 require 'google_drive'
 
-ENV['SSL_CERT_FILE'] =
-  Gem.loaded_specs['google-api-client'].full_gem_path + '/lib/cacerts.pem'
-
 class TestGoogleDrive < Test::Unit::TestCase
   # Random string is added to avoid conflict with existing file titles.
   PREFIX = 'google-drive-ruby-test-4101301e303c-'.freeze


### PR DESCRIPTION
Since `google-api-client` gem is deprecated and unmaintained anymore, we should move to service specific gems,
`google-apis-drive_v3` and `google-apis-sheets_v4`, instead.

closes #392
