### PR TITLE
Port keyword arguments to ruby 3 syntax

### DIFF
--- a/lib/google_drive/worksheet.rb
+++ b/lib/google_drive/worksheet.rb
@@ -631,8 +631,8 @@ module GoogleDrive
     #     1, 1, 1, 1,
     #     {bottom: Google::Apis::SheetsV4::Border.new(
     #       style: "DOUBLE", color: GoogleDrive::Worksheet::Colors::BLACK)})
-    def update_borders(top_row, left_col, num_rows, num_cols, borders)
-      request = Google::Apis::SheetsV4::UpdateBordersRequest.new(borders)
+    def update_borders(top_row, left_col, num_rows, num_cols, **borders)
+      request = Google::Apis::SheetsV4::UpdateBordersRequest.new(**borders)
       request.range = v4_range_object(top_row, left_col, num_rows, num_cols)
       add_request({update_borders: request})
     end


### PR DESCRIPTION
The `borders` argument is expecting a Hash, in Ruby 3 arguments changed the keyword params syntax.
See: https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/